### PR TITLE
change invitation link to a badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Use replit branch, this is old
 
-[Link for invitation](https://discord.com/api/oauth2/authorize?client_id=811591623242154046&permissions=8&scope=bot%20applications.commands)
+[![Link For Invitation](https://img.shields.io/badge/Invite%20to%20Your%20server-7289DA?style=for-the-badge&logo=discord&logoColor=white)](https://discord.com/api/oauth2/authorize?client_id=811591623242154046&permissions=8&scope=bot%20applications.commands)
+<!-- [Link for invitation](https://discord.com/api/oauth2/authorize?client_id=811591623242154046&permissions=8&scope=bot%20applications.commands) -->
 
 <img src="https://github.com/alvinbengeorge/alfred-discord-bot/blob/replit/Krypton.png">
 


### PR DESCRIPTION
instead of "link for invitation" now it is a badge saying "invite to your server" and discord logo