### PR TITLE
Make yml_embed case insensitive, and better devop

### DIFF
--- a/src/create_embed.py
+++ b/src/create_embed.py
@@ -144,6 +144,8 @@ def embed_from_yaml(yaml: str, ctx_author) -> discord.Embed:
     Generates an embed from given yaml string
     """
     info = safe_load(yaml)
+    info = {k.lower():v for k,v in info.items()}
+    
     info['color'] = get_color(info.get('color', None))
     print(info)
 

--- a/src/create_embed.py
+++ b/src/create_embed.py
@@ -145,9 +145,10 @@ def embed_from_yaml(yaml: str, ctx_author) -> discord.Embed:
     """
     info = safe_load(yaml)
     info = {k.lower():v for k,v in info.items()}
-    
+
     info['color'] = get_color(info.get('color', None))
-    print(info)
+    # print(info)
+    print(f"Creating Emebed for: '{ctx_author.name}' aka '{ctx_author.nick}' in '{ctx_author.guild}'")
 
     embed = discord.Embed(**info)
     


### PR DESCRIPTION
they keys for yml/yaml is not insensitive and the devop prints where the embed is created instead of the whole data.