### PR TITLE
Development

### DIFF
--- a/cogs/Configuration.py
+++ b/cogs/Configuration.py
@@ -555,12 +555,21 @@ class Configuration(commands.Cog):
             )
         )
 
-    @config.subcommand(name="autoreact", description="Automatically reacts to every message in a channel")
-    async def autoreactslash(self, inter, channel: GuildChannel = ef.defa(ChannelType.text), emojis: str = ""):
+    @config.subcommand(
+        name="autoreact",
+        description="Automatically reacts to every message in a channel",
+    )
+    async def autoreactslash(
+        self, inter, channel: GuildChannel = ef.defa(ChannelType.text), emojis: str = ""
+    ):
         await self.autoreact(inter, channel, Emojis=emojis)
 
-    @config.subcommand(name="removereact", description="Clears autoreact from a channel")
-    async def removeautoreactslash(self, inter, channel: GuildChannel = ef.defa(ChannelType.text)):
+    @config.subcommand(
+        name="removereact", description="Clears autoreact from a channel"
+    )
+    async def removeautoreactslash(
+        self, inter, channel: GuildChannel = ef.defa(ChannelType.text)
+    ):
         await self.remove_autoreact(inter, channel=channel)
 
     @commands.command(aliases=["autoreaction"])
@@ -576,7 +585,7 @@ class Configuration(commands.Cog):
                     title="Permissions Denied",
                     description="You cannot set autoreact, you do not have admin privilege",
                     color=self.CLIENT.re[8],
-                    thumbnail=self.CLIENT.user.avatar
+                    thumbnail=self.CLIENT.user.avatar,
                 )
             )
             return
@@ -588,10 +597,8 @@ class Configuration(commands.Cog):
                         "You need to mention a channel\n'autoreact #channel :one:|:two:|:three:"
                     ),
                     color=self.CLIENT.re[8],
-                    author=getattr(
-                        ctx, "author", getattr(ctx, "user", None)
-                    ),
-                    thumbnail=self.CLIENT.user.avatar
+                    author=getattr(ctx, "author", getattr(ctx, "user", None)),
+                    thumbnail=self.CLIENT.user.avatar,
                 )
             )
             return
@@ -631,9 +638,7 @@ class Configuration(commands.Cog):
                     title="Permissions Denied",
                     description="You cannot remove autoreact, you do not have admin privilege",
                     color=self.CLIENT.re[8],
-                    author=getattr(
-                        ctx, "author", getattr(ctx, "user", None)
-                    )
+                    author=getattr(ctx, "author", getattr(ctx, "user", None)),
                 )
             )
             return

--- a/cogs/Configuration.py
+++ b/cogs/Configuration.py
@@ -562,6 +562,7 @@ class Configuration(commands.Cog):
     async def autoreactslash(
         self, inter, channel: GuildChannel = ef.defa(ChannelType.text), emojis: str = ""
     ):
+        await inter.response.defer()
         await self.autoreact(inter, channel, Emojis=emojis)
 
     @config.subcommand(
@@ -570,6 +571,7 @@ class Configuration(commands.Cog):
     async def removeautoreactslash(
         self, inter, channel: GuildChannel = ef.defa(ChannelType.text)
     ):
+        await inter.response.defer()
         await self.remove_autoreact(inter, channel=channel)
 
     @commands.command(aliases=["autoreaction"])
@@ -642,6 +644,15 @@ class Configuration(commands.Cog):
                 )
             )
             return
+        if not channel:
+            await ctx.send(
+                embed=ef.cembed(
+                    title="This time",
+                    description="Mention a channel, in the `channel` field",
+                    color=self.CLIENT.re[8],
+                    thumbnail=self.CLIENT.user.avatar,
+                )
+            )
         if not channel.id in self.CLIENT.autor:
             await ctx.send(
                 embed=ef.cembed(

--- a/cogs/Configuration.py
+++ b/cogs/Configuration.py
@@ -519,7 +519,7 @@ class Configuration(commands.Cog):
                 )
             )
 
-    @nextcord.slash_command(
+    @config.subcommand(
         name="sealfred",
         description="Checks for behaviours like kicking out or banning regularly",
     )
@@ -555,6 +555,14 @@ class Configuration(commands.Cog):
             )
         )
 
+    @config.subcommand(name="autoreact", description="Automatically reacts to every message in a channel")
+    async def autoreactslash(self, inter, channel: GuildChannel = ef.defa(ChannelType.text), emojis: str = ""):
+        await self.autoreact(inter, channel, Emojis=emojis)
+
+    @config.subcommand(name="removereact", description="Clears autoreact from a channel")
+    async def removeautoreactslash(self, inter, channel: GuildChannel = ef.defa(ChannelType.text)):
+        await self.remove_autoreact(inter, channel=channel)
+
     @commands.command(aliases=["autoreaction"])
     @commands.check(ef.check_command)
     async def autoreact(
@@ -568,6 +576,7 @@ class Configuration(commands.Cog):
                     title="Permissions Denied",
                     description="You cannot set autoreact, you do not have admin privilege",
                     color=self.CLIENT.re[8],
+                    thumbnail=self.CLIENT.user.avatar
                 )
             )
             return
@@ -579,6 +588,10 @@ class Configuration(commands.Cog):
                         "You need to mention a channel\n'autoreact #channel :one:|:two:|:three:"
                     ),
                     color=self.CLIENT.re[8],
+                    author=getattr(
+                        ctx, "author", getattr(ctx, "user", None)
+                    ),
+                    thumbnail=self.CLIENT.user.avatar
                 )
             )
             return
@@ -618,6 +631,9 @@ class Configuration(commands.Cog):
                     title="Permissions Denied",
                     description="You cannot remove autoreact, you do not have admin privilege",
                     color=self.CLIENT.re[8],
+                    author=getattr(
+                        ctx, "author", getattr(ctx, "user", None)
+                    )
                 )
             )
             return

--- a/cogs/DataCleanup.py
+++ b/cogs/DataCleanup.py
@@ -4,8 +4,10 @@ from nextcord.ext import commands
 
 # Use nextcord.slash_command()
 
+
 def requirements():
     return []
+
 
 class DataCleanup(commands.Cog):
     def __init__(self, CLIENT: commands.Bot):
@@ -18,69 +20,75 @@ class DataCleanup(commands.Cog):
         self.queue_song()
 
     def queue_song(self):
-        count=0
+        count = 0
         while True:
             for i in self.CLIENT.queue_song:
                 if not self.CLIENT.get_guild(i):
-                    count+=1
+                    count += 1
                     del self.CLIENT.queue_song[i]
                     break
-            else: break
+            else:
+                break
         print("QUEUE_SONG ->", count)
 
     def config(self):
-        count=0
+        count = 0
         while True:
-            for i in self.CLIENT.config['snipe']:
+            for i in self.CLIENT.config["snipe"]:
                 if not self.CLIENT.get_guild(i):
-                    count+=1
-                    self.CLIENT.config['snipe'].remove(i)
+                    count += 1
+                    self.CLIENT.config["snipe"].remove(i)
                     break
-            else: break
+            else:
+                break
         print("CONFIG SNIPE ->", count)
-        
-        count=0
+
+        count = 0
         while True:
-            for i in self.CLIENT.config['respond']:
+            for i in self.CLIENT.config["respond"]:
                 if not self.CLIENT.get_guild(i):
-                    count+=1
-                    self.CLIENT.config['respond'].remove(i)
+                    count += 1
+                    self.CLIENT.config["respond"].remove(i)
                     break
-            else: break
+            else:
+                break
         print("CONFIG RESPOND ->", count)
 
-        count=0
+        count = 0
         while True:
-            for i, j in self.CLIENT.config['youtube'].items():
+            for i, j in self.CLIENT.config["youtube"].items():
                 if (not self.CLIENT.get_channel(i)) or j == set():
-                    count+=1
-                    del self.CLIENT.config['youtube'][i]
+                    count += 1
+                    del self.CLIENT.config["youtube"][i]
                     break
-            else: break
+            else:
+                break
         print("CONFIG YOUTUBE ->", count)
 
-        count=0
+        count = 0
         while True:
-            for i, j in self.CLIENT.config['welcome'].items():
-                if not (self.CLIENT.get_guild(i) and self.CLIENT.get_channel(j['channel'])):
-                    count+=1
-                    del self.CLIENT.config['welcome'][i]
+            for i, j in self.CLIENT.config["welcome"].items():
+                if not (
+                    self.CLIENT.get_guild(i) and self.CLIENT.get_channel(j["channel"])
+                ):
+                    count += 1
+                    del self.CLIENT.config["welcome"][i]
                     break
-            else: break
+            else:
+                break
         print("CONFIG WELCOME ->", count)
 
-        count=0
+        count = 0
         while True:
-            for i, j in self.CLIENT.config['security']:
+            for i, j in self.CLIENT.config["security"]:
                 if not all([self.CLIENT.get_guild(i), self.CLIENT.get_channel(j)]):
-                    count+=1
-                    del self.CLIENT.config['security'][i]
+                    count += 1
+                    del self.CLIENT.config["security"][i]
                     break
-            else: break
+            else:
+                break
         print("CONFIG SECURITY ->", count)
 
-    
 
-
-def setup(client,**i):
-    client.add_cog(DataCleanup(client,**i))
+def setup(client, **i):
+    client.add_cog(DataCleanup(client, **i))

--- a/cogs/DataCleanup.py
+++ b/cogs/DataCleanup.py
@@ -1,0 +1,86 @@
+import nextcord
+import utils.External_functions as ef
+from nextcord.ext import commands
+
+# Use nextcord.slash_command()
+
+def requirements():
+    return []
+
+class DataCleanup(commands.Cog):
+    def __init__(self, CLIENT: commands.Bot):
+        self.CLIENT = CLIENT
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        print("DELETING MISC DATA")
+        self.config()
+        self.queue_song()
+
+    def queue_song(self):
+        count=0
+        while True:
+            for i in self.CLIENT.queue_song:
+                if not self.CLIENT.get_guild(i):
+                    count+=1
+                    del self.CLIENT.queue_song[i]
+                    break
+            else: break
+        print("QUEUE_SONG ->", count)
+
+    def config(self):
+        count=0
+        while True:
+            for i in self.CLIENT.config['snipe']:
+                if not self.CLIENT.get_guild(i):
+                    count+=1
+                    self.CLIENT.config['snipe'].remove(i)
+                    break
+            else: break
+        print("CONFIG SNIPE ->", count)
+        
+        count=0
+        while True:
+            for i in self.CLIENT.config['respond']:
+                if not self.CLIENT.get_guild(i):
+                    count+=1
+                    self.CLIENT.config['respond'].remove(i)
+                    break
+            else: break
+        print("CONFIG RESPOND ->", count)
+
+        count=0
+        while True:
+            for i, j in self.CLIENT.config['youtube'].items():
+                if (not self.CLIENT.get_channel(i)) or j == set():
+                    count+=1
+                    del self.CLIENT.config['youtube'][i]
+                    break
+            else: break
+        print("CONFIG YOUTUBE ->", count)
+
+        count=0
+        while True:
+            for i, j in self.CLIENT.config['welcome'].items():
+                if not (self.CLIENT.get_guild(i) and self.CLIENT.get_channel(j['channel'])):
+                    count+=1
+                    del self.CLIENT.config['welcome'][i]
+                    break
+            else: break
+        print("CONFIG WELCOME ->", count)
+
+        count=0
+        while True:
+            for i, j in self.CLIENT.config['security']:
+                if not all([self.CLIENT.get_guild(i), self.CLIENT.get_channel(j)]):
+                    count+=1
+                    del self.CLIENT.config['security'][i]
+                    break
+            else: break
+        print("CONFIG SECURITY ->", count)
+
+    
+
+
+def setup(client,**i):
+    client.add_cog(DataCleanup(client,**i))

--- a/cogs/Embed.py
+++ b/cogs/Embed.py
@@ -140,11 +140,14 @@ def yaml_to_dict(yaml):
 
 
 class MSetup:
-    def __init__(self, ctx, CLIENT):
+    def __init__(
+        self, ctx: Union[commands.context.Context, nextcord.Interaction], CLIENT
+    ):
         self.ctx = ctx
         self.USER = getattr(ctx, "author", getattr(ctx, "user", None))
         self.CLIENT = CLIENT
-        self.di = {}
+        self.END = False
+        self.di: dict = {}
         self.EDIT_MESSAGE = None
         self.INSTRUCTION = None
         self.OPTIONS = ef.m_options
@@ -216,8 +219,13 @@ class MSetup:
                 embed=embed_from_dict(self.di, self.ctx, self.CLIENT)
             )
 
-    async def change_setup(self, MODE: str) -> str:
-        self.SETUP_VALUE = MODE
+    async def change_setup(self, MODE: str, inter: nextcord.Interaction) -> str:
+        if self.END:
+            await inter.response.send_message(
+                content="🔚This Msetup Session Ended, please use `import` and reply to this embed by creating a new `/msetup`",
+                ephemeral=True,
+            )
+            return
         self.SETUP_VALUE = MODE.lower()
         await self.EDIT_MESSAGE.edit(
             embed=ef.cembed(
@@ -402,7 +410,7 @@ class Embed(commands.Cog):
 
                     if text.lower() == "cancel":
                         await ctx.send("Cancelled")
-                        return
+                        break
 
                     if text.lower().startswith("send"):
                         if validate_url(text[5:]):
@@ -441,6 +449,8 @@ class Embed(commands.Cog):
                 break
             except:
                 print(traceback.format_exc())
+
+        session.END = True
 
     @commands.command()
     @commands.check(ef.check_command)

--- a/main.py
+++ b/main.py
@@ -49,16 +49,10 @@ old_youtube_vid: dict = {}
 youtube_cache: dict = {}
 deleted_message: dict = {}
 config: dict = {
-    "snipe": [
-        841026124174983188,
-        822445271019421746,
-        830050310181486672,
-        912569937116147772,
-    ],
+    "snipe": [],
     "respond": [],
     "youtube": {},
     "welcome": {},
-    "ticket": {},
     "security": {},
     "commands": {},
     "reactions": {},
@@ -77,11 +71,11 @@ re: list = [
     {},
     {},
     -1,
-    "",
-    "205",
+    "", # re[5] if free
+    "", # re[6] is free
     {},
-    5360,
-    "48515587275%3A0AvceDiA27u1vT%3A26",
+    5360, # re[8] -> color
+    "", # re[9] is free
     {},
 ]
 youtube: list = []
@@ -106,7 +100,7 @@ FFMPEG_OPTIONS = {
     "options": "-vn",
 }
 
-print("Starting")
+print("INITIALISING CLIENT")
 
 
 def prefix_check(client_variable, message):

--- a/main.py
+++ b/main.py
@@ -71,11 +71,11 @@ re: list = [
     {},
     {},
     -1,
-    "", # re[5] if free
-    "", # re[6] is free
+    "",  # re[5] if free
+    "",  # re[6] is free
     {},
-    5360, # re[8] -> color
-    "", # re[9] is free
+    5360,  # re[8] -> color
+    "",  # re[9] is free
     {},
 ]
 youtube: list = []

--- a/utils/assets.py
+++ b/utils/assets.py
@@ -405,7 +405,7 @@ class Msetup_DropDownSelect(nextcord.ui.Select):
         if interaction.user.id != self.user.id:
             await interaction.response.send_message("Not your Embed 🔪", ephemeral=True)
             return
-        await self.func(self.values[0])
+        await self.func(self.values[0], interaction)
 
 
 class Msetup_DropDownView(nextcord.ui.View):


### PR DESCRIPTION
# Data Clean up
- Added an entire cog to filter out if the data is required or not
- This was done by checking through each key of a variable or sometimes channel
- If they return `None`, [**Nothing to worry about, all of this happens at on_ready**], that entire `key: value` will be deleted
- This could prevent useless data, and the major impact lies in `queue_song` variable

# Slash commands for autoreact
Added `/config autoreact` and `/config removereact` and linked it to their respective prefix commands

# Handler for MSETUP selection
Now returns a message asking the user to redo `'msetup` command and import from the embed, instead of just editing the `SETUP VALUE` even after the session is over
<img width="476" alt="image" src="https://user-images.githubusercontent.com/69302420/181260582-5b7cf5b6-899d-4a9e-bbed-151fe2173f21.png">
